### PR TITLE
WIP: singularity workarounds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN wget --progress=bar:force -P /tmp http://www.neuro.uni-jena.de/cat12/${CAT_F
  && chmod +x /opt/spm/spm12 /opt/spm/*.sh \
  && chmod +x /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/CAT.glnx86/CAT_* \
  && rm -rf /tmp/*
-RUN cp /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.txt /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.m
+RUN rm -f /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.txt
 ENV PATH="${PATH}:/opt/spm/standalone"
 ENV SPMROOT /opt/spm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN wget --progress=bar:force -P /tmp http://www.neuro.uni-jena.de/cat12/${CAT_F
  && /opt/spm/run_spm12.sh ${MCRROOT} --version \
  && chmod +x /opt/spm/spm12 /opt/spm/*.sh \
  && rm -rf /tmp/*
+RUN cp /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.txt /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.m
 ENV PATH="${PATH}:/opt/spm/standalone"
 ENV SPMROOT /opt/spm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN wget --progress=bar:force -P /tmp http://www.neuro.uni-jena.de/cat12/${CAT_F
  && mv /opt/${CAT_FULLVERSION}_${MATLAB_VERSION}_MCR_Linux /opt/spm \
  && /opt/spm/run_spm12.sh ${MCRROOT} --version \
  && chmod +x /opt/spm/spm12 /opt/spm/*.sh \
+ && chmod +x /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/CAT.glnx86/CAT_* \
  && rm -rf /tmp/*
 RUN cp /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.txt /opt/spm/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_long_main.m
 ENV PATH="${PATH}:/opt/spm/standalone"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ Example (segmentation of T1w image)
  /data/my_dataset/sub-0001/anat/sub-0001_T1w.nii
 ```
 
+Example using singularity (longitudinal segmentation)
+----
+
+You need to make sure to map `$HOME/.matlab` if you are running in contained
+mode, because the MCR will write into that folder.
+
+```bash
+singularity build cat12-latest.sif docker://jhuguetn/cat12:latest
+singularity run --cleanenv --contain \
+  -B $PWD:/data \
+  -B $HOME/.matlab \
+  cat12-latest.sif \
+  -s /opt/spm -m /opt/mcr/v93 -b /opt/spm/standalone/cat_standalone_segment_long.m /data/my_dataset/sub-01/ses-0{1,2,3}/anat/sub-01_T1w.nii
+```
+
 Credits
 -------
 Jordi Huguet ([BarcelonaBeta Brain Research Center](http://barcelonabeta.org))


### PR DESCRIPTION
We are using singularity and the docker container needs some minor changes to be usable:

1. At least for the longitudinal batch at runtime the standalone code will replace the content of the pseudo compiled ".m" file with the content of a ".txt" file with the same name. Since with singularity the content of the container is read-only, this will fail and we replace at build-time. In theory this should also prevent docker runs from creating tiny unnamed volumes.

2. The container content often belongs to `root` with singularity and the CAT12 mex folder needs executable bit set for groups and others.

I also added a minimal example for a singularity invocation in the README.

WIP, we still haven't verified a batch completely, but it's looking good so far.