### PR TITLE
WIP: use much smaller MCR core variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20210416
+FROM octomike/matlab-compiler-runtime:9.3-core
 
 MAINTAINER Jordi Huguet <jhuguet@barcelonabeta.org>
 
@@ -10,22 +10,10 @@ LABEL maintainer="jhuguet@barcelonabeta.org"
 # set the working directory
 WORKDIR /root
 
-# install dependencies and prereqs
-RUN apt-get update \
- && apt-get -y install wget nano unzip libxext6 libxt6 moreutils \
- && apt-get clean
-
-# install Matlab MCR at /opt/mcr
+# install MCR/standalone version of SPM12 plus CAT12 at /opt/spm
 ENV MATLAB_VERSION R2017b
 ENV MCR_VERSION v93
-RUN mkdir /tmp/mcr_install \
- && mkdir /opt/mcr \
- && wget --progress=bar:force -P /tmp/mcr_install https://ssd.mathworks.com/supportfiles/downloads/R2017b/deployment_files/R2017b/installers/glnxa64/MCR_R2017b_glnxa64_installer.zip \
- && unzip -q /tmp/mcr_install/MCR_R2017b_glnxa64_installer.zip -d /tmp/mcr_install \
- && /tmp/mcr_install/install -destinationFolder /opt/mcr -agreeToLicense yes -mode silent
 ENV MCRROOT /opt/mcr/${MCR_VERSION}
-
-# install MCR/standalone version of SPM12 plus CAT12 at /opt/spm
 ENV SPM_VERSION 12
 ENV SPM_REVISION r7771
 ENV MCR_INHIBIT_CTF_LOCK 1


### PR DESCRIPTION
This PR is  stretch.. :)

In https://github.com/octomike/matlab-compiler-runtime I build and collect MCR versions, including a much smaller, but experimental `-core` variant of the MCR. [In my tests](https://hub.docker.com/r/octomike/cat12/tags) I was able to reduce the dockerhub reported container size from 5.07 to 1.64 GB. It's looking good so far, the code is starting/running, but there is no guarantee it does indeed cover all corner cases of cat12/spm12.

This PR bases the Dockerfile on the `octomike/matlab-compiler-runtime:9.3-core` image to

+ reduce file size
+ speed up build time a little
+ simplify the Dockerfile

What do you think?